### PR TITLE
Add lldpd

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -6,7 +6,7 @@ LABEL fastly.net101.name=base
 WORKDIR /root
 
 RUN apt-get update; apt-get upgrade -y;
-RUN apt-get install -y ucf iproute mtr-tiny traceroute iputils-ping less tcpdump net-tools curl
+RUN apt-get install -y ucf iproute mtr-tiny traceroute iputils-ping less tcpdump net-tools curl lldpd
 
 COPY ./run.sh /bin/run.sh
 

--- a/base/run.sh
+++ b/base/run.sh
@@ -1,2 +1,10 @@
 #!/bin/sh
-bash /lab/run.sh
+CUSTOM_SCRIPT="/lab/run.sh"
+
+service lldpd restart
+
+if [ -z $CUSTOM_SCRIPT ]; then
+	bash $CUSTOM_SCRIPT
+else
+	sleep infinity
+fi

--- a/base/test/docker-compose.yaml
+++ b/base/test/docker-compose.yaml
@@ -1,0 +1,34 @@
+version: '2.1'
+
+services:
+    host00:
+        hostname: host00
+        build:
+            context: ..
+            dockerfile: Dockerfile
+        image: net101_base_test
+        networks:
+            test_net101_base_image:
+                ipv4_address: 10.255.255.50
+        cap_add:
+            - NET_ADMIN
+    host01:
+        hostname: host01
+        build:
+            context: ..
+            dockerfile: Dockerfile
+        image: net101_base_test
+        networks:
+            test_net101_base_image:
+                ipv4_address: 10.255.255.51
+        cap_add:
+            - NET_ADMIN
+
+networks:
+    test_net101_base_image:
+        enable_ipv6: false
+        driver: bridge
+        ipam:
+            driver: default
+            config:
+                - subnet: 10.255.255.0/24


### PR DESCRIPTION
DONT MERGE

So this adds lldpd but it doesn't work as I am not sure how to configure it so the linux bridge forwards the LLDP datagrams. In theory this should work:

```
echo 16384 | sudo tee /sys/class/net/<bridge_name>/bridge/group_fwd_mask
```

But I am not sure how to apply that directly by `docker` or how to even apply it manually on a mac with the "native" docker.